### PR TITLE
Made the project Pypi publishable

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,70 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "cwl-oscar"
+version = "0.1.0"
+description = "A lightweight Workflow Management System to Orchestrate CWL Workflows on OSCAR clusters"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "cwltest>=2.6.20250314152537",
+    "cwltool>=3.1.20250715140722",
+    "future>=0.16.0",
+    "minio>=7.2.0",
+    "oscar-python>=1.3.1",
+    "pydantic>=2.0.0",
+    "pyjwt>=1.6.4",
+    "python-dotenv>=0.19.0",
+    "requests>=2.18.2",
+    "typing-extensions>=3.7.4",
+]


### PR DESCRIPTION
This pull request introduces initial support for publishing the Python package to PyPI and adds essential project metadata and dependencies. The main changes are the addition of a GitHub Actions workflow for automated publishing and the creation of a `pyproject.toml` file to define the package and its requirements.

**Automated Publishing Workflow:**

- Added `.github/workflows/python-publish.yml` to automate building and publishing the package to PyPI when a release is published. This workflow builds the distribution and uploads it to PyPI using trusted publishing.

**Project Metadata and Dependencies:**

- Created `pyproject.toml` with project metadata (`name`, `version`, `description`, etc.) and specified required Python dependencies for the package.